### PR TITLE
Moved quotes inside span tags for key and string values.

### DIFF
--- a/src/prettyPrint.ts
+++ b/src/prettyPrint.ts
@@ -92,15 +92,11 @@ class PrintWriter {
   }
 
   public printKey(key: string) {
-    this.buffer.push('\"');
-    this.buffer.push(`<span class="json-key">${escapeHtml(key)}</span>`);
-    this.buffer.push('\"');
+    this.buffer.push(`<span class="json-key">\"${escapeHtml(key)}\"</span>`);
   }
 
   public printString(value: string) {
-    this.buffer.push('\"');
-    this.buffer.push(`<span class="json-string">${escapeHtml(value)}</span>`);
-    this.buffer.push('\"');
+    this.buffer.push(`<span class="json-string">\"${escapeHtml(value)}\"</span>`);
   }
 
   public printBoolean(value: boolean) {


### PR DESCRIPTION
Rendered HTML looks much better when quotes of key and string literals are a part of the same style. Included quotes inside <span class="json-key"> and <span class="json-string"> tags.