### PR TITLE
Create silent option to avoid exception for unknown types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ lib
 lib-esm
 stats
 _bundles
+__tests__/*.d.ts
+__tests__/*.js
+__tests__/*.js.map
+src/*.d.ts
+src/*.js
+src/*.js.map
+build

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ With [a nice CSS](https://github.com/amelki/json-pretty-html/blob/master/style.c
 
 <img src="https://cdn.pbrd.co/images/GNTkTu9.png" alt="Result" width="350">
 
+## Options
+
+* indent: String to indent with. Defaults to 2 html spaces.
+* silent: Suppresses exceptions for unknown types. For instance function. Defaults to false. When set to true the type will be outputted instead.
+
+```js
+var html = prettyHtml(json, json.dimensions, {
+  indent: '&nbsp;&nbsp;',
+  silent: false
+});
+```
+
 ## CSS
 
 You can use the default ['darcula' like stylesheet](https://github.com/amelki/json-pretty-html/blob/master/style.css).

--- a/__tests__/prettyPrint.spec.ts
+++ b/__tests__/prettyPrint.spec.ts
@@ -59,3 +59,8 @@ test('escapedHtml', () => {
   const json = { foo: 'hello <span> world', 'the<key>': 'other', bar: 'with "double" quotes' };
   expect(prettyPrint(json)).toBe('<div class="json-pretty">{<br>&nbsp;&nbsp;"<span class="json-key">foo</span>":&nbsp;"<span class="json-string">hello &lt;span&gt; world</span>",<br>&nbsp;&nbsp;"<span class="json-key">the&lt;key&gt;</span>":&nbsp;"<span class="json-string">other</span>",<br>&nbsp;&nbsp;"<span class="json-key">bar</span>":&nbsp;"<span class="json-string">with &quot;double&quot; quotes</span>"<br>}</div>');
 });
+
+test('unexpectedTypes', () => {
+  const json = { foo: 'test', bar: () => { const test = 'test'; } };
+  expect(prettyPrint(json)).toBe('<div class="json-pretty">{<br>&nbsp;&nbsp;"<span class="json-key">foo</span>":&nbsp;"<span class="json-string">test</span>",<br>&nbsp;&nbsp;"<span class="json-key">bar</span>":&nbsp;function<br>}</div>');
+});

--- a/src/prettyPrint.ts
+++ b/src/prettyPrint.ts
@@ -169,7 +169,11 @@ const printObject = (object: object, out: PrintWriter, idt: number, selection: o
         out.print('undefined');
         break;
       default:
-        throw new Error(`Don''t know what to do with ${typeof value}`);
+        if (options.silent) {
+          out.print(typeof value);
+        } else {
+          throw new Error(`Don''t know what to do with ${typeof value}`);
+        }
     }
     if (i < keys.length - 1) {
       out.print(',');
@@ -230,7 +234,7 @@ const printArray = (array: {}[], out: PrintWriter, idt: number, selection: objec
 
 export interface Options {
   indent?: string;
-
+  silent?: boolean;
 }
 
 const prettyPrint = (object: object, selection?: object, options?: Options): string => {


### PR DESCRIPTION
Functions currently throw an exception, but i use this to output a readable error object. So i don't want any exceptions from pretty print.

```js
	var json = { foo: 'test', bar: () => { const test = 'test'; } };
	var html = prettyPrint.default(json, json.dimensions, {silent: true});
	document.write(html);
```